### PR TITLE
Update guidance-for-using-open-internet-tools.md

### DIFF
--- a/content/security/guidance-for-using-open-internet-tools.md
+++ b/content/security/guidance-for-using-open-internet-tools.md
@@ -27,6 +27,7 @@ This guidance gives you:
 - a [quick checklist](#quick-checklist) to help you decide if you can use an OIT
 - reasons why you [might](#why-oits-are-an-opportunity), or [might not](#why-oits-are-a-risk), want to use an OIT
 - things you [must think about](#using-oits) when using an OIT, such as [data protection](#privacy-and-personal-information)
+- information on who to contact if you would like help or advice
 
 <a id="overview"></a>
 
@@ -49,6 +50,7 @@ To help you decide if you can use an OIT to work on an MOJ task, consider the fo
 - is the task information classified as anything other than `OFFICIAL` or `OFFICIAL-SENSITIVE`?
 - does the task information include any data identifiable as being about someone?
 - is this the first time anyone has used the tool for MOJ business?
+- does the tool require access to your account or other data you can access? for example, asks for authorisation on your MOJ Google G-Suite or Microsoft Office 365 account; installs a browser extension or is a plug-in for existing OITs we use such as Slack or Confluence/Jira
 - could there be damaging consequences if the task information you work with using the tool is:
   - lost
   - stolen
@@ -112,9 +114,9 @@ This guidance helps you:
 
 ### Privacy and personal information
 
-Data protection legislation makes you responsible for personal information you work with. You must keep it safe and secure. In particular, you must follow General Data Protection Regulation (GDPR) obligations.
+Data protection legislation makes you responsible for personal information you work with. You must keep it safe and secure. In particular, you must follow Data Protection Act 2018 and General Data Protection Regulation (GDPR) obligations.
 
-Don't use OITs for storing personal data until you have consent from anyone affected. Don't use OITs if unlawful disclosure of the information they process might cause damage or distress.
+Don't use OITs for storing personal data until you have consider the implications such as needing to obtain consent or update existing privacy policies or notices. Don't use OITs if unlawful disclosure of the information they process might cause damage or distress.
 
 Data protection legislation might also limit _where_ you can process personal data. An OIT should have a privacy statement that describes where it stores or processes data. Be ready to contact the OIT provider for more information about this aspect of their service.
 


### PR DESCRIPTION
- Added "tells you who to contact"
- DPA2018 reference
- added questions about access to other data (grants access to G-Suite/O365 or installs into the browser)

Thoughts:
- #163 is something the guidance has to say, but I doubt whether people do this!
- Should we add some further technical details such as using MOJ G-Suite or O365 for SSO to the OIT if its available?
- Should we add something about not paying for things by GPC, and to use a proper procurement?
- I'm not a fan of links to the Intranet on the basis not everyone can access the Intranet at the same time (I usually operate a group inbox and list that in every place under the sun)

Overall, I like it (a lot) but I think its too long once the person has read it once. I almost feel like there should be a checkbox or summary bullet point structure as well for quick referencing - example, so the person looking at the OIT can show what s/he has checked to their line manager.